### PR TITLE
Foreground Service Example

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,23 +4,6 @@
     package="inc.combustion.example">
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
-
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
-                     android:usesPermissionFlags="neverForLocation"
-                     tools:targetApi="s" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH"
-                     android:maxSdkVersion="30"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-                     android:maxSdkVersion="30"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
-                     android:maxSdkVersion="30"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
-                     android:maxSdkVersion="30"/>
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"
-                     android:maxSdkVersion="30"/>
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -28,11 +11,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CombustionIncEngineering">
-        <service
-            android:name="inc.combustion.service.CombustionService"
-            android:enabled="true"
-            android:exported="false" />
-
         <activity
             android:name="inc.combustion.example.MainActivity"
             android:exported="true"


### PR DESCRIPTION
- Shows how to create a Notification and start the Combustion Service as a foreground service.
- The related framework API changes are introduced in [this PR.](https://github.com/combustion-inc/combustion-android-ble/pull/10) 
- Each app using the framework runs a separate instance of the Combustion Service, with a separate notification.  See the screenshot below.

![Combustion_ForegroundService_Screenshot_20220404_181558](https://user-images.githubusercontent.com/90232532/161661454-cf93af0c-4b56-4467-a6c1-429036f4a449.png)

