### PR TITLE
Added set color and set id actions, display battery status

### DIFF
--- a/app/src/main/java/inc/combustion/example/components/RadioButtonRow.kt
+++ b/app/src/main/java/inc/combustion/example/components/RadioButtonRow.kt
@@ -1,0 +1,39 @@
+package inc.combustion.engineering.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RadioButtonRow(text: String, selectedValue: String, onClickListener: (String) -> Unit) {
+    Row(
+        Modifier
+        .fillMaxWidth()
+        .selectable(
+            selected = (text == selectedValue),
+            onClick = {
+                onClickListener(text)
+            }
+        )
+    ) {
+        RadioButton(
+            selected = (text == selectedValue),
+            onClick = {
+                onClickListener(text)
+            }
+        )
+        Text(
+            text = text,
+            modifier = Modifier
+                .align(alignment = Alignment.CenterVertically)
+        )
+    }
+}

--- a/app/src/main/java/inc/combustion/example/components/SingleSelectionDialog.kt
+++ b/app/src/main/java/inc/combustion/example/components/SingleSelectionDialog.kt
@@ -1,0 +1,65 @@
+package inc.combustion.engineering.ui.components
+
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun SingleSelectDialog(title: String,
+                       optionsList: List<String>,
+                       defaultSelected: Int,
+                       submitButtonText: String,
+                       onSubmitButtonClick: (Int) -> Unit,
+                       onDismissRequest: () -> Unit) {
+
+    var selectedOption by remember { mutableStateOf(defaultSelected) }
+
+    Dialog(onDismissRequest = { onDismissRequest.invoke() }) {
+        Surface(shape = RoundedCornerShape(10.dp)
+        ) {
+            Column(modifier = Modifier.padding(10.dp)) {
+                Text(
+                    text = title,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally),
+                    color = MaterialTheme.colors.onPrimary,
+                    style = MaterialTheme.typography.subtitle2,
+                    textAlign = TextAlign.Center
+                )
+                LazyColumn {
+                    items(optionsList) {
+                        RadioButtonRow(
+                            it,
+                            optionsList[selectedOption]
+                        ) { selectedValue ->
+                            selectedOption = optionsList.indexOf(selectedValue)
+                        }
+                    }
+                }
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onSubmitButtonClick.invoke(selectedOption)
+                        onDismissRequest.invoke()
+                    },
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    Text(text = submitButtonText)
+                }
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/inc/combustion/example/devices/DevicesScreenState.kt
+++ b/app/src/main/java/inc/combustion/example/devices/DevicesScreenState.kt
@@ -28,6 +28,8 @@
 package inc.combustion.example.devices
 
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
 
 /**
  * Data object for DeviceScreen state.
@@ -42,5 +44,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
 data class DevicesScreenState(
     val probes: SnapshotStateMap<String, ProbeState>,
     val onUnitsClick: (ProbeState) -> Unit,
-    val onBluetoothClick: (ProbeState) -> Unit
+    val onBluetoothClick: (ProbeState) -> Unit,
+    val onSetProbeColorClick: (String, ProbeColor) -> Unit,
+    val onSetProbeIDClick: (String, ProbeID) -> Unit
 )

--- a/app/src/main/java/inc/combustion/example/devices/DevicesViewModel.kt
+++ b/app/src/main/java/inc/combustion/example/devices/DevicesViewModel.kt
@@ -33,9 +33,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import inc.combustion.example.LOG_TAG
-import inc.combustion.framework.service.DeviceDiscoveredEvent
-import inc.combustion.framework.service.ProbeUploadState
-import inc.combustion.framework.service.DeviceManager
+import inc.combustion.framework.service.*
+import inc.combustion.example.R
 import kotlinx.coroutines.launch
 import kotlin.IllegalArgumentException
 import kotlinx.coroutines.flow.*
@@ -51,7 +50,18 @@ class DevicesViewModel(
     private val deviceManager : DeviceManager,
 ) : ViewModel() {
 
+    data class SnackBarMessage(
+        var id : String,
+        var resource : Int
+    )
+
     var probes = mutableStateMapOf<String, ProbeState>()
+        private set
+
+    var isSnackBarShowing: MutableState<Boolean> = mutableStateOf(false)
+        private set
+
+    var snackBarMessage: MutableState<SnackBarMessage> = mutableStateOf(SnackBarMessage("", 0))
         private set
 
     init {
@@ -154,6 +164,40 @@ class DevicesViewModel(
     }
 
     /**
+     * ViewModel processing a color choice for a probe
+     *
+     * @param serial serial number of probe to update
+     * @param color new color value for probe
+     *
+     * @see ProbeState
+     * @see ProbeColor
+     */
+    fun setProbeColor(serial: String, color: ProbeColor) {
+        deviceManager.setProbeColor(serial, color) {
+            if(!it) {
+                showSnackBarMessage(serial, R.string.set_color_fail)
+            }
+        }
+    }
+
+    /**
+     * ViewModel processing a id choice for a probe
+     *
+     * @param serial serial number of probe to update
+     * @param id new id value for probe
+     *
+     * @see ProbeState
+     * @see ProbeID
+     */
+    fun setProbeID(serial: String, id: ProbeID) {
+        deviceManager.setProbeID(serial, id) {
+            if(!it) {
+                showSnackBarMessage(serial, R.string.set_id_fail)
+            }
+        }
+    }
+
+    /**
      * ViewModel handler for when a probe is discovered.
      *
      * @param serialNumber Serial number of the device.
@@ -191,5 +235,16 @@ class DevicesViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Create Snackbar message with given ID and String
+     *
+     * @param id to print next to message
+     * @param resource message to print in snack bar
+     */
+    private fun showSnackBarMessage(id: String, resource: Int) {
+        snackBarMessage.value = SnackBarMessage(id, resource)
+        isSnackBarShowing.value = true
     }
 }

--- a/app/src/main/java/inc/combustion/example/devices/ProbeState.kt
+++ b/app/src/main/java/inc/combustion/example/devices/ProbeState.kt
@@ -77,6 +77,7 @@ data class ProbeState(
     var recordRange: MutableState<String> = mutableStateOf(""),
     var color: MutableState<String> = mutableStateOf(""),
     var id: MutableState<String> = mutableStateOf(""),
+    var batteryStatus: MutableState<String> = mutableStateOf(""),
     var instantRead: MutableState<String> = mutableStateOf("")
 ) {
     enum class Units(val string: String) {
@@ -136,6 +137,7 @@ data class ProbeState(
         recordsDownloaded.value = downloads
         color.value = state.color.toString()
         id.value = state.id.toString()
+        batteryStatus.value = state.batteryStatus.toString()
 
         instantRead.value = if(state.instantRead != null) {
             String.format("%.1f", state.instantRead?.let { convertTemperature(it) })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="no_open_connections_message">cannot connect! All connections used. &#9785;&#65039;</string>
     <string name="out_of_range_message">cannot connect! Out of range. &#9785;&#65039;</string>
     <string name="connected_message">connected! &#128293;</string>
+    <string name="set_color_fail">Failed to set Probe Color</string>
+    <string name="set_id_fail">Failed to set Probe ID</string>
 </resources>


### PR DESCRIPTION
Added 'Set Probe Color' and 'Set Probe ID' radio buttons on the Probe Card. Buttons are only enable once you connect to the probe.

Battery status is now visible and the value is driven by the combustion BLE framework. It will show either 'OK' or 'LOW_BATTERY'.