### PR TITLE
Preliminary Prediction Support

### DIFF
--- a/app/src/main/java/inc/combustion/example/MainScreen.kt
+++ b/app/src/main/java/inc/combustion/example/MainScreen.kt
@@ -54,12 +54,12 @@ class AppState(
     val isScanning: State<Boolean>,
     val bluetoothIsOn: State<Boolean>,
     val onShareTextData: (String, String) -> Unit,
-    val showMeasurements: MutableState<Boolean> = mutableStateOf(true),
-    val showPlot: MutableState<Boolean> = mutableStateOf(true),
+    val showMeasurements: MutableState<Boolean> = mutableStateOf(false),
+    val showPlot: MutableState<Boolean> = mutableStateOf(false),
     val showDetails: MutableState<Boolean> = mutableStateOf(false),
     val showInstantRead: MutableState<Boolean> = mutableStateOf(true),
     val showTemperatures: MutableState<Boolean> = mutableStateOf(true),
-    val showPrediction: MutableState<Boolean> = mutableStateOf(true)
+    val showPrediction: MutableState<Boolean> = mutableStateOf(false)
 ) {
     val noDevicesReasonString: String
         get() = if(!bluetoothIsOn.value) {

--- a/app/src/main/java/inc/combustion/example/MainScreen.kt
+++ b/app/src/main/java/inc/combustion/example/MainScreen.kt
@@ -57,7 +57,9 @@ class AppState(
     val showMeasurements: MutableState<Boolean> = mutableStateOf(true),
     val showPlot: MutableState<Boolean> = mutableStateOf(true),
     val showDetails: MutableState<Boolean> = mutableStateOf(false),
-    val showInstantRead: MutableState<Boolean> = mutableStateOf(true)
+    val showInstantRead: MutableState<Boolean> = mutableStateOf(true),
+    val showTemperatures: MutableState<Boolean> = mutableStateOf(true),
+    val showPrediction: MutableState<Boolean> = mutableStateOf(true)
 ) {
     val noDevicesReasonString: String
         get() = if(!bluetoothIsOn.value) {

--- a/app/src/main/java/inc/combustion/example/components/CardComponents.kt
+++ b/app/src/main/java/inc/combustion/example/components/CardComponents.kt
@@ -505,6 +505,22 @@ fun ProbeDetails(
                     value = probeState.rssi.value.toString(),
                     color = color
                 )
+                CardDataItem(
+                    label = "Network Hops",
+                    value = probeState.hopCount.value,
+                    color = color
+                )
+                CardDivider()
+                CardDataItem(
+                    label = "Estimated Core",
+                    value = probeState.virtualCoreSensor.value,
+                    color = color
+                )
+                CardDataItem(
+                    label = "Estimated Surface",
+                    value = probeState.virtualSurfaceSensor.value,
+                    color = color
+                )
                 CardDivider()
                 CardDataItem(
                     label = "Color",

--- a/app/src/main/java/inc/combustion/example/components/CardComponents.kt
+++ b/app/src/main/java/inc/combustion/example/components/CardComponents.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import inc.combustion.example.R
 import inc.combustion.framework.service.LoggedProbeDataPoint
+import inc.combustion.framework.service.ProbePredictionMode
 import java.util.*
 
 @Composable
@@ -294,13 +295,12 @@ fun MeasurementsCard(
 
 @Composable
 fun PredictionsCard(
-    title: String = "Predictions",
+    title: String = "Prediction",
     probeState: ProbeState,
     cardIsExpanded: MutableState<Boolean>,
 ) {
     ExpandableAppCard(title = title, cardIsExpanded = cardIsExpanded){
-        // TODO
-        // SensorMeasurements(probeState = probeState)
+        PredictionDetails(probeState = probeState)
     }
 }
 
@@ -473,6 +473,45 @@ fun SensorMeasurements(
     }
 }
 
+@Composable
+fun PredictionDetails(
+    probeState: ProbeState
+) {
+    val color = DataColor(probeState = probeState)
+
+    if(probeState.connectionState.value != ProbeState.ConnectionState.CONNECTED) {
+        CardProgressIndicator(reason = "Please Connect...")
+    }
+    else {
+        Row(
+            modifier = Modifier.fillMaxWidth()
+        ){
+            Text(
+                modifier = Modifier
+                    .weight(1.0f),
+                color = color,
+                style = MaterialTheme.typography.h2,
+                textAlign = TextAlign.Center,
+                text = probeState.prediction.value
+            )
+        }
+        CardDataItem(
+            label = "Cooking To",
+            value = probeState.setPointTemperatureC.value,
+            color = color
+        )
+        CardDataItem(
+            label = "Cooking State",
+            value = probeState.predictionState.value,
+            color = color
+        )
+        CardDataItem(
+            label = "Cook Progress",
+            value = probeState.percentThroughCook.value,
+            color = color
+        )
+    }
+}
 
 @Composable
 fun ProbeDetails(
@@ -535,6 +574,27 @@ fun ProbeDetails(
                 CardDataItem(
                     label = "Estimated Surface",
                     value = probeState.virtualSurfaceSensor.value,
+                    color = color
+                )
+                CardDivider()
+                CardDataItem(
+                    label = "Prediction Mode",
+                    value = probeState.predictionMode.value,
+                    color = color
+                )
+                CardDataItem(
+                    label = "Prediction Type",
+                    value = probeState.predictionType.value,
+                    color = color
+                )
+                CardDataItem(
+                    label = "Heat Start",
+                    value = probeState.heatStartTemperatureC.value,
+                    color = color
+                )
+                CardDataItem(
+                    label = "Estimated Core",
+                    value = probeState.estimateCoreC.value,
                     color = color
                 )
                 CardDivider()

--- a/app/src/main/java/inc/combustion/example/components/CardComponents.kt
+++ b/app/src/main/java/inc/combustion/example/components/CardComponents.kt
@@ -240,7 +240,6 @@ fun DeviceSummaryCard(
             onBluetoothClick = onConnectionClick,
             onUnitsClick = onUnitsClick
         )
-        //AllTemperaturesMeasurements(probeState = probeState)
         SummaryMeasurements(probeState = probeState)
         SummaryDetails(probeState = probeState)
     }
@@ -272,13 +271,36 @@ fun InstantReadCard(
 }
 
 @Composable
+fun TemperaturesCard(
+    title: String = "Temperatures",
+    probeState: ProbeState,
+    cardIsExpanded: MutableState<Boolean>,
+) {
+    ExpandableAppCard(title = title, cardIsExpanded = cardIsExpanded){
+        TemperatureMeasurements(probeState = probeState)
+    }
+}
+
+@Composable
 fun MeasurementsCard(
-    title: String = "Measurements",
+    title: String = "Sensors",
     probeState: ProbeState,
     cardIsExpanded: MutableState<Boolean>,
 ) {
     ExpandableAppCard(title = title, cardIsExpanded = cardIsExpanded){
         SensorMeasurements(probeState = probeState)
+    }
+}
+
+@Composable
+fun PredictionsCard(
+    title: String = "Predictions",
+    probeState: ProbeState,
+    cardIsExpanded: MutableState<Boolean>,
+) {
+    ExpandableAppCard(title = title, cardIsExpanded = cardIsExpanded){
+        // TODO
+        // SensorMeasurements(probeState = probeState)
     }
 }
 
@@ -385,22 +407,22 @@ fun SummaryMeasurements(
             Modifier.weight(1.0f)
         )
         CardTemperature(
-            label = "Tip",
-            value = probeState.T1,
+            label = "Core",
+            value = probeState.coreTemperature,
             color = color,
             Modifier.weight(1.0f)
         )
     }
     Row {
         CardTemperature(
-            label = "Middle",
-            value = probeState.T4,
+            label = "Surface",
+            value = probeState.surfaceTemperature,
             color = color,
             Modifier.weight(1.0f)
         )
         CardTemperature(
-            label = "Handle",
-            value = probeState.T8,
+            label = "Ambient",
+            value = probeState.ambientTemperature,
             color = color,
             Modifier.weight(1.0f)
         )
@@ -408,22 +430,16 @@ fun SummaryMeasurements(
 }
 
 @Composable
-fun AllTemperaturesMeasurements(
-    probeState: ProbeState
+fun TemperatureMeasurements(
+    probeState: ProbeState,
+    modifier: Modifier = Modifier
 ) {
     val color = DataColor(probeState = probeState)
-
     Row {
-        CardTemperature(
-            label = "Instant Read",
-            value = probeState.instantRead,
-            color = color,
-            Modifier.weight(1.0f)
-        )
+        CardTemperature("Core", probeState.coreTemperature, color, modifier.weight(1.0f))
+        CardTemperature("Surface", probeState.surfaceTemperature, color, modifier.weight(1.0f))
+        CardTemperature("Ambient", probeState.ambientTemperature, color, modifier.weight(1.0f))
     }
-    SensorMeasurements(
-        probeState = probeState,
-    )
 }
 
 @Composable

--- a/app/src/main/java/inc/combustion/example/components/ProbeState.kt
+++ b/app/src/main/java/inc/combustion/example/components/ProbeState.kt
@@ -32,10 +32,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import inc.combustion.framework.service.DeviceConnectionState
-import inc.combustion.framework.service.Probe
-import inc.combustion.framework.service.ProbeBatteryStatus
-import inc.combustion.framework.service.ProbeUploadState
+import inc.combustion.framework.service.*
 
 /**
  * State data object for a probe.  Binds the state between the DeviceScreen's ViewModel
@@ -56,6 +53,7 @@ import inc.combustion.framework.service.ProbeUploadState
  * @property id the probes ID setting.
  * @property instantRead the probe's Instant Read value.
  * @property connectionDescription friendly description of connection state
+ * @property samplePeriod: the normal data sample period
  */
 data class ProbeState(
     val serialNumber: String,
@@ -83,7 +81,10 @@ data class ProbeState(
     var batteryStatus: MutableState<String> = mutableStateOf(""),
     var instantRead: MutableState<String> = mutableStateOf(""),
     var connectionDescription: MutableState<String> = mutableStateOf(""),
-    var samplePeriod: MutableState<String> = mutableStateOf("0.0")
+    var samplePeriod: MutableState<String> = mutableStateOf("0.0"),
+    var virtualCoreSensor: MutableState<String> = mutableStateOf(""),
+    var virtualSurfaceSensor: MutableState<String> = mutableStateOf(""),
+    var hopCount: MutableState<String> = mutableStateOf("")
 ) {
     enum class Units(val string: String) {
         FAHRENHEIT("Fahrenheit"),
@@ -207,6 +208,10 @@ data class ProbeState(
             DeviceConnectionState.DISCONNECTING -> "Connected"
             DeviceConnectionState.DISCONNECTED -> "Disconnected"
         }
+
+        virtualCoreSensor.value = state.virtualSensors.virtualCoreSensor.toString()
+        virtualSurfaceSensor.value = state.virtualSensors.virtualSurfaceSensor.toString()
+        hopCount.value = state.hopCount.toString()
     }
 
     /**

--- a/app/src/main/java/inc/combustion/example/components/ProbeState.kt
+++ b/app/src/main/java/inc/combustion/example/components/ProbeState.kt
@@ -57,11 +57,11 @@ import inc.combustion.framework.service.*
  */
 data class ProbeState(
     val serialNumber: String,
-    var macAddress: MutableState<String> = mutableStateOf("TBD"),
-    var firmwareVersion: MutableState<String?> = mutableStateOf(null),
-    var hardwareRevision: MutableState<String?> = mutableStateOf(null),
-    var rssi: MutableState<Int> = mutableStateOf(0),
-    var temperaturesCelsius: SnapshotStateList<Double> = mutableStateListOf(
+    val macAddress: MutableState<String> = mutableStateOf("TBD"),
+    val firmwareVersion: MutableState<String?> = mutableStateOf(null),
+    val hardwareRevision: MutableState<String?> = mutableStateOf(null),
+    val rssi: MutableState<Int> = mutableStateOf(0),
+    val temperaturesCelsius: SnapshotStateList<Double> = mutableStateListOf(
         0.0,
         0.0,
         0.0,
@@ -71,20 +71,23 @@ data class ProbeState(
         0.0,
         0.0
     ),
-    var connectionState: MutableState<ConnectionState> = mutableStateOf(ConnectionState.OUT_OF_RANGE),
-    var units: MutableState<Units> = mutableStateOf(Units.FAHRENHEIT),
-    var uploadStatus: MutableState<String> = mutableStateOf(""),
-    var recordsDownloaded: MutableState<Int> = mutableStateOf(0),
-    var recordRange: MutableState<String> = mutableStateOf(""),
-    var color: MutableState<String> = mutableStateOf(""),
-    var id: MutableState<String> = mutableStateOf(""),
-    var batteryStatus: MutableState<String> = mutableStateOf(""),
-    var instantRead: MutableState<String> = mutableStateOf(""),
-    var connectionDescription: MutableState<String> = mutableStateOf(""),
-    var samplePeriod: MutableState<String> = mutableStateOf("0.0"),
-    var virtualCoreSensor: MutableState<String> = mutableStateOf(""),
-    var virtualSurfaceSensor: MutableState<String> = mutableStateOf(""),
-    var hopCount: MutableState<String> = mutableStateOf("")
+    val connectionState: MutableState<ConnectionState> = mutableStateOf(ConnectionState.OUT_OF_RANGE),
+    val units: MutableState<Units> = mutableStateOf(Units.FAHRENHEIT),
+    val uploadStatus: MutableState<String> = mutableStateOf(""),
+    val recordsDownloaded: MutableState<Int> = mutableStateOf(0),
+    val recordRange: MutableState<String> = mutableStateOf(""),
+    val color: MutableState<String> = mutableStateOf(""),
+    val id: MutableState<String> = mutableStateOf(""),
+    val batteryStatus: MutableState<String> = mutableStateOf(""),
+    val instantRead: MutableState<String> = mutableStateOf(""),
+    val connectionDescription: MutableState<String> = mutableStateOf(""),
+    val samplePeriod: MutableState<String> = mutableStateOf("0.0"),
+    val virtualCoreSensor: MutableState<String> = mutableStateOf(""),
+    val virtualSurfaceSensor: MutableState<String> = mutableStateOf(""),
+    val hopCount: MutableState<String> = mutableStateOf(""),
+    val coreTemperature: MutableState<String> = mutableStateOf(""),
+    val surfaceTemperature: MutableState<String> = mutableStateOf(""),
+    val ambientTemperature: MutableState<String> = mutableStateOf("")
 ) {
     enum class Units(val string: String) {
         FAHRENHEIT("Fahrenheit"),
@@ -180,6 +183,24 @@ data class ProbeState(
             T6.value = "---"
             T7.value = "---"
             T8.value = "---"
+        }
+
+        coreTemperature.value = state.coreTemperature?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+           "---"
+        }
+
+        surfaceTemperature.value = state.surfaceTemperature?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+            "---"
+        }
+
+        ambientTemperature.value = state.ambientTemperature?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+            "---"
         }
 
         // convert to friendly string

--- a/app/src/main/java/inc/combustion/example/components/ProbeState.kt
+++ b/app/src/main/java/inc/combustion/example/components/ProbeState.kt
@@ -87,7 +87,15 @@ data class ProbeState(
     val hopCount: MutableState<String> = mutableStateOf(""),
     val coreTemperature: MutableState<String> = mutableStateOf(""),
     val surfaceTemperature: MutableState<String> = mutableStateOf(""),
-    val ambientTemperature: MutableState<String> = mutableStateOf("")
+    val ambientTemperature: MutableState<String> = mutableStateOf(""),
+    val predictionState: MutableState<String> = mutableStateOf(""),
+    val predictionMode: MutableState<String> = mutableStateOf(""),
+    val predictionType: MutableState<String> = mutableStateOf(""),
+    val setPointTemperatureC: MutableState<String> = mutableStateOf(""),
+    val heatStartTemperatureC: MutableState<String> = mutableStateOf(""),
+    val percentThroughCook: MutableState<String> = mutableStateOf(""),
+    val prediction: MutableState<String> = mutableStateOf(""),
+    val estimateCoreC: MutableState<String> = mutableStateOf("")
 ) {
     enum class Units(val string: String) {
         FAHRENHEIT("Fahrenheit"),
@@ -233,6 +241,63 @@ data class ProbeState(
         virtualCoreSensor.value = state.virtualSensors.virtualCoreSensor.toString()
         virtualSurfaceSensor.value = state.virtualSensors.virtualSurfaceSensor.toString()
         hopCount.value = state.hopCount.toString()
+
+        predictionState.value = state.predictionState?.let {
+            when(it) {
+                ProbePredictionState.PROBE_NOT_INSERTED -> "Not Inserted"
+                ProbePredictionState.PROBE_INSERTED -> "Inserted"
+                ProbePredictionState.WARMING -> "Warming"
+                ProbePredictionState.PREDICTING -> "Predicting"
+                ProbePredictionState.REMOVAL_PREDICTION_DONE -> "Ready to Remove"
+                ProbePredictionState.RESERVED_STATE_5 -> "Reserved 5"
+                ProbePredictionState.RESERVED_STATE_6 -> "Reserved 6"
+                ProbePredictionState.RESERVED_STATE_7 -> "Reserved 7"
+                ProbePredictionState.RESERVED_STATE_8 -> "Reserved 8"
+                ProbePredictionState.RESERVED_STATE_9 -> "Reserved 9"
+                ProbePredictionState.RESERVED_STATE_10 -> "Reserved 10"
+                ProbePredictionState.RESERVED_STATE_11 ->  "Reserved 11"
+                ProbePredictionState.RESERVED_STATE_12 -> "Reserved 12"
+                ProbePredictionState.RESERVED_STATE_13 -> "Reserved 13"
+                ProbePredictionState.RESERVED_STATE_14 -> "Reserved 14"
+                ProbePredictionState.UNKNOWN -> "Unknown"
+            }
+        } ?: run { "" }
+
+        predictionMode.value = state.predictionMode?.let { it.toString() } ?: run { ProbePredictionMode.NONE.toString() }
+        predictionType.value = state.predictionType?.let { it.toString() } ?: run { ProbePredictionType.NONE.toString() }
+
+        setPointTemperatureC.value = state.setPointTemperatureC?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+            ""
+        }
+
+        heatStartTemperatureC.value = state.heatStartTemperatureC?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+            "---"
+        }
+
+        prediction.value = state.predictionS?.let {
+            String.format("%02d:%02d", it.toInt() / 60, it.toInt() % 60)
+        } ?: run {
+            "--:--"
+        }
+
+        estimateCoreC.value = state.estimatedCoreC?.let {
+            String.format("%.1f", convertTemperature(it))
+        } ?: run {
+            "---"
+        }
+
+        if(state.heatStartTemperatureC != null && state.estimatedCoreC != null && state.setPointTemperatureC != null) {
+            val start = state.heatStartTemperatureC!!
+            val end = state.setPointTemperatureC!!
+            val core = state.estimatedCoreC!!
+            percentThroughCook.value = "${(((core - start) / (end - start)) * 100.0).toInt()} %"
+        } else {
+            percentThroughCook.value = ""
+        }
     }
 
     /**

--- a/app/src/main/java/inc/combustion/example/details/DetailsScreen.kt
+++ b/app/src/main/java/inc/combustion/example/details/DetailsScreen.kt
@@ -50,6 +50,8 @@ data class DetailsScreenState(
     val plotCardIsExpanded: MutableState<Boolean>,
     val detailsCardIsExpanded: MutableState<Boolean>,
     val instantReadCardIsExpanded: MutableState<Boolean>,
+    val temperaturesCardIsExpanded: MutableState<Boolean>,
+    val predictionsCardIsExpanded: MutableState<Boolean>,
     val onConnectClick: () -> Unit,
     val onSetProbeColorClick: (ProbeColor) -> Unit,
     val onSetProbeIDClick: (ProbeID) -> Unit,
@@ -77,6 +79,8 @@ fun DetailsScreen(
         plotCardIsExpanded = appState.showPlot,
         detailsCardIsExpanded = appState.showDetails,
         instantReadCardIsExpanded = appState.showInstantRead,
+        temperaturesCardIsExpanded = appState.showTemperatures,
+        predictionsCardIsExpanded = appState.showPrediction,
         onConnectClick =  { viewModel.toggleConnection() },
         onSetProbeColorClick = { color -> viewModel.setProbeColor(color) },
         onSetProbeIDClick = { id -> viewModel.setProbeID(id) },
@@ -156,6 +160,20 @@ fun DetailsContent(
                         cardIsExpanded = screenState.instantReadCardIsExpanded,
                     )
                 }
+                item {
+                    TemperaturesCard(
+                        probeState = screenState.probeState,
+                        cardIsExpanded = screenState.temperaturesCardIsExpanded,
+                    )
+                }
+                /* TODO
+                item {
+                    PredictionsCard(
+                        probeState = screenState.probeState,
+                        cardIsExpanded = screenState.predictionsCardIsExpanded,
+                    )
+                }
+                 */
                 item {
                     MeasurementsCard(
                         probeState = screenState.probeState,

--- a/app/src/main/java/inc/combustion/example/details/DetailsScreen.kt
+++ b/app/src/main/java/inc/combustion/example/details/DetailsScreen.kt
@@ -166,18 +166,10 @@ fun DetailsContent(
                         cardIsExpanded = screenState.temperaturesCardIsExpanded,
                     )
                 }
-                /* TODO
                 item {
                     PredictionsCard(
                         probeState = screenState.probeState,
                         cardIsExpanded = screenState.predictionsCardIsExpanded,
-                    )
-                }
-                 */
-                item {
-                    MeasurementsCard(
-                        probeState = screenState.probeState,
-                        cardIsExpanded = screenState.measurementCardIsExpanded,
                     )
                 }
                 item {
@@ -186,6 +178,12 @@ fun DetailsContent(
                         probeState = screenState.probeState,
                         cardIsExpanded = screenState.plotCardIsExpanded,
                         plotDataStartTimestamp = screenState.probeDataStartTimestamp
+                    )
+                }
+                item {
+                    MeasurementsCard(
+                        probeState = screenState.probeState,
+                        cardIsExpanded = screenState.measurementCardIsExpanded,
                     )
                 }
                 item {


### PR DESCRIPTION
- Update Main Screen Summary Card to display core, surface, and ambient.
- Add Prediction Card to Details Screen.
- Add prediction fields to Details Card on Details Screen.