### PR TITLE
DROID-23: Android 13 Support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     } catch (e) {
         implementation("com.github.combustion-inc:combustion-android-ble:$combustion_framework_version")
     }
-    implementation("androidx.core:core-ktx:1.7.0")
+    implementation('androidx.core:core-ktx:1.9.0')
     implementation("androidx.appcompat:appcompat:$appcompat_version")
     implementation("com.google.android.material:material:$material_version")
     implementation("androidx.compose.ui:ui:$compose_version")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,12 +19,12 @@ def getVersionName = { ->
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "inc.combustion.example"
         minSdk 24
-        targetSdk 31
+        targetSdk 33
         versionCode 2002
         versionName getVersionName()
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
         applicationId "inc.combustion.example"
         minSdk 24
         targetSdk 33
-        versionCode 2002
+        versionCode 2003
         versionName getVersionName()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="inc.combustion.example">
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/inc/combustion/example/MainActivity.kt
+++ b/app/src/main/java/inc/combustion/example/MainActivity.kt
@@ -72,7 +72,8 @@ class MainActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks {
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 arrayOf(
                     Manifest.permission.BLUETOOTH_SCAN,
-                    Manifest.permission.BLUETOOTH_CONNECT
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.POST_NOTIFICATIONS
                 )
             }
             // Lower than API Level 31

--- a/app/src/main/java/inc/combustion/example/details/DetailsViewModel.kt
+++ b/app/src/main/java/inc/combustion/example/details/DetailsViewModel.kt
@@ -113,7 +113,7 @@ class DetailsViewModel (
         private val serialNumber: String,
         private val temperatureUnitsConversion: (Double) -> Double
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(DetailsViewModel::class.java)) {
                 @Suppress("UNCHECKED_CAST")
                 return DetailsViewModel(serialNumber, deviceManager, temperatureUnitsConversion) as T

--- a/app/src/main/java/inc/combustion/example/devices/DevicesViewModel.kt
+++ b/app/src/main/java/inc/combustion/example/devices/DevicesViewModel.kt
@@ -114,7 +114,7 @@ class DevicesViewModel(
         private val deviceManager: DeviceManager,
         private val temperatureUnitsConversion: (Double) -> Double
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(DevicesViewModel::class.java)) {
                 @Suppress("UNCHECKED_CAST")
                 return DevicesViewModel(deviceManager, temperatureUnitsConversion) as T

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlin_version = '1.6.10'
-        android_gradle_version = '7.2.1'
+        android_gradle_version = '7.3.1'
         compose_version = '1.1.1'
         appcompat_version = '1.4.1'
         material_version = '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         navigation_common_ktx_version = "2.4.1"
         activity_compose_version = "1.4.0"
         compose_compiler_version = '1.5.21'
-        kable_core_version = '0.10.3'
+        kable_core_version = '0.20.1'
         easypermissions_ktx_version = '1.0.0'
         settings_compose_version = '0.7.2'
         google_services_version = '4.3.10'

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,27 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.7.10'
         android_gradle_version = '7.3.1'
-        compose_version = '1.1.1'
-        appcompat_version = '1.4.1'
-        material_version = '1.5.0'
-        lifecycle_runtime_ktx_version = '2.4.1'
-        navigation_compose_version = "2.4.1"
-        navigation_common_ktx_version = "2.4.1"
-        activity_compose_version = "1.4.0"
+        compose_version = '1.3.1'
+        appcompat_version = '1.5.1'
+        material_version = '1.7.0'
+        lifecycle_runtime_ktx_version = '2.5.1'
+        navigation_compose_version = '2.5.3'
+        navigation_common_ktx_version = '2.5.3'
+        activity_compose_version = '1.6.1'
         compose_compiler_version = '1.5.21'
         kable_core_version = '0.20.1'
         easypermissions_ktx_version = '1.0.0'
-        settings_compose_version = '0.7.2'
+        settings_compose_version = '0.13.0'
         google_services_version = '4.3.10'
-        lifecycle_service_version = '2.4.1'
+        lifecycle_service_version = '2.5.1'
         play_services_base_version = '18.0.1'
         play_services_auth_version = '20.1.0'
-        junit_version = '1.1.3'
-        espresso_core_version = '3.4.0'
+        junit_version = '1.1.4'
+        espresso_core_version = '3.5.0'
         mpandroidchart_version = 'v3.1.0'
-        viewbinding_version = '1.1.0'
+        viewbinding_version = '1.3.1'
         combustion_framework_version = 'develop-SNAPSHOT'
     }
     repositories {


### PR DESCRIPTION
- Updates for Android 13 support, dependency update for ble framework changes
- Update the gradle version to 7.3.1
- Updated most of the dependencies, bumped kotlin version to 1.7.10, minor ViewModelProvider.Factory API change

Did not update the `desugar_jdk_libs:1.1.5` since it requires an additional gradle update to a alpha release. 




