### PR TITLE
DROID-139: Fix Initial UI State

### DIFF
--- a/app/src/main/java/inc/combustion/example/MainActivity.kt
+++ b/app/src/main/java/inc/combustion/example/MainActivity.kt
@@ -159,10 +159,17 @@ class MainActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks {
                         if(bluetoothTurnedOff) {
                             // We clear devices when Bluetooth is off.  This isn't required, just
                             // how the example behaves.
-                            DeviceManager.instance.clearDevices()
+                            repository.clearDevices()
                         }
                     }
                 }
+            }
+
+            // Same as above, we clear devices when Bluetooth is off.  This isn't required,
+            // just how the example behaves
+            bluetoothIsOn.value = repository.networkFlow.value.bluetoothOn
+            if(!bluetoothIsOn.value) {
+                repository.clearDevices()
             }
         }
 
@@ -244,12 +251,12 @@ class MainActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks {
             service.cancel(it)
         }
 
-        // Unbind Combustion Service. The DeviceManager will automatically unbind the connection
+        // Stops the Combustion Service. The DeviceManager will automatically unbind the connection
         // when all references reach 0.
         //
         // See README.md for further guidelines on managing Service Lifecycle in more
         // complex apps.
-        DeviceManager.unbindCombustionService()
+        DeviceManager.stopCombustionService()
 
         super.onDestroy()
     }


### PR DESCRIPTION
Test Cases:
- First time launch (e.g. permissions prompt), Bluetooth enabled.
- First time launch (e.g. permissions prompt), Bluetooth disabled.
- Subsequent launch (e.g. permissions already accepted), Bluetooth enabled, and Bluetooth disabled.

See related PR in combustion-android-ble.